### PR TITLE
Add Crash Analytics documentation

### DIFF
--- a/Android/GeneXus Libraries/README.md
+++ b/Android/GeneXus Libraries/README.md
@@ -1,3 +1,3 @@
 # GeneXus Libraries
 
-This libraries correspond to the [GeneXus Super App Render](../../SuperAppRender.md). In order to avoid including binaries in the repository, they're temporarily available for [download from GeneXus Site](https://www.genexus.com/en/developers/downloadcenter?data=5963) (contact your local agent in order to get access).
+This libraries correspond to the [GeneXus Super App Render](../../SuperAppRender.md). In order to avoid including binaries in the repository, they're temporarily available for [download from GeneXus Site](https://www.genexus.com/en/developers/downloadcenter?data=5995) (contact your local agent in order to get access).

--- a/iOS/CrashAnalytics/Crashlytics.md
+++ b/iOS/CrashAnalytics/Crashlytics.md
@@ -1,0 +1,18 @@
+# Crashlytics for iOS
+
+## Setup
+
+It is possible for the Super App to receive Crashlytics reports for crashes that occur during the execution of a Mini App.
+
+In order to achieve this, a couple of steps must be followed:
+
+1. Implement the protocol `GXCrashAnalyticsService` from `GXCoreBL` module. An example implementation is provided for Firebase Crashlytics [GXFirebaseCrashAnalyticsService.swift](GXFirebaseCrashAnalyticsService.swift).
+2. Register your crash analytics implementation as part of `GXUIApplicationExecutionEnvironment` initialization or before it. For example, as part of [extension library initialization](../SampleExternalObject/SampleExObjLibrary.swift#L9) add the following:
+ 
+```swift
+GXCoreBLServices.registerCrashAnalyticsService(GXFirebaseCrashAnalyticsService.shared)
+```
+
+Now, every time a fatal exception is thrown while a Mini App is executing, it will be forwarded to the Crashlytics profile configured for the project along with the Mini App Id and Version so it is easier to find when and under which circumstances the crash happened.
+
+Note the provided example is for Firebase Crashlytics, but the same could applies for other Crash Analytics provider.

--- a/iOS/CrashAnalytics/Crashlytics.md
+++ b/iOS/CrashAnalytics/Crashlytics.md
@@ -15,4 +15,4 @@ GXCoreBLServices.registerCrashAnalyticsService(GXFirebaseCrashAnalyticsService.s
 
 Now, every time a fatal exception is thrown while a Mini App is executing, it will be forwarded to the Crashlytics profile configured for the project along with the Mini App Id and Version so it is easier to find when and under which circumstances the crash happened.
 
-Note the provided example is for Firebase Crashlytics, but the same could applies for other Crash Analytics provider.
+Note the provided example is for Firebase Crashlytics, but the same applies for other Crash Analytics provider.

--- a/iOS/CrashAnalytics/GXFirebaseCrashAnalyticsService.swift
+++ b/iOS/CrashAnalytics/GXFirebaseCrashAnalyticsService.swift
@@ -1,0 +1,60 @@
+//
+//  GXFirebaseCrashAnalyticsService.swift
+//
+
+import GXCoreBL
+import FirebaseCore
+import FirebaseCrashlytics
+
+class GXFirebaseCrashAnalyticsService: NSObject {
+	
+	static let shared: GXFirebaseCrashAnalyticsService = .init()
+	
+	private override init() {
+		super.init()
+	}
+}
+
+extension GXFirebaseCrashAnalyticsService: GXCoreBL.GXCrashAnalyticsService {
+	private var crashlytics: FirebaseCrashlytics.Crashlytics {
+		FirebaseCrashlytics.Crashlytics.crashlytics()
+	}
+	
+	var didCrashOnPreviousExecution: Bool {
+		crashlytics.didCrashDuringPreviousExecution()
+	}
+	
+	func setCustomValue(_ value: String, forKey key: String) {
+		crashlytics.setCustomValue(value, forKey: key)
+	}
+	
+	func setCustomKeysAndValues(_ valuesByKey: [String: String]) {
+		crashlytics.setCustomKeysAndValues(valuesByKey)
+	}
+	
+	func removeCustomValue(forKey key: String) {
+		crashlytics.setCustomValue(nil, forKey: key)
+	}
+	
+	func removeCustomValues(forKeys keys: [String]) {
+		var valuesByKeyToRemove: [String: Any] = .init(minimumCapacity: keys.count)
+		keys.forEach { valuesByKeyToRemove[$0] = NSNull() }
+		crashlytics.setCustomKeysAndValues(valuesByKeyToRemove)
+	}
+	
+	func setUserId(_ userId: String) {
+		crashlytics.setUserID(userId)
+	}
+	
+	func removeUserId() {
+		crashlytics.setUserID(nil)
+	}
+	
+	func log(message: String) {
+		crashlytics.log(message)
+	}
+	
+	func record(error: Error) {
+		crashlytics.record(error: error)
+	}
+}

--- a/iOS/ExampleSuperApp.xcodeproj/project.pbxproj
+++ b/iOS/ExampleSuperApp.xcodeproj/project.pbxproj
@@ -146,6 +146,8 @@
 		AE7ECBF226A065FB00B8E41B /* GXUCStarRating.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = GXUCStarRating.xcframework; sourceTree = "<group>"; };
 		AE7ECBF326A065FB00B8E41B /* GXFoundation.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = GXFoundation.xcframework; sourceTree = "<group>"; };
 		AE7ECBF426A065FB00B8E41B /* GXCoreUI.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = GXCoreUI.xcframework; sourceTree = "<group>"; };
+		AEE860AF2A20D02E0013C7ED /* Crashlytics.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = Crashlytics.md; sourceTree = "<group>"; };
+		AEE860B02A20D0350013C7ED /* GXFirebaseCrashAnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GXFirebaseCrashAnalyticsService.swift; sourceTree = "<group>"; };
 		AEEE718426DEC1780039C5E5 /* SampleExObjHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleExObjHandler.swift; sourceTree = "<group>"; };
 		AEEE718526DEC1780039C5E5 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		AEEE718626DEC1780039C5E5 /* SampleExObjLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleExObjLibrary.swift; sourceTree = "<group>"; };
@@ -200,6 +202,7 @@
 				AEFB723727A2EFD8005324FB /* README.md */,
 				AE5080152697504100926F54 /* ExampleSuperApp */,
 				AEEE718326DEC1780039C5E5 /* SampleExternalObject */,
+				AEE860AE2A20CFDE0013C7ED /* CrashAnalytics */,
 				AE5080B52697557A00926F54 /* GeneXus Frameworks */,
 				AE5080142697504100926F54 /* Products */,
 			);
@@ -249,6 +252,15 @@
 				AE7ECBF126A065FB00B8E41B /* YAJL.xcframework */,
 			);
 			path = "GeneXus Frameworks";
+			sourceTree = "<group>";
+		};
+		AEE860AE2A20CFDE0013C7ED /* CrashAnalytics */ = {
+			isa = PBXGroup;
+			children = (
+				AEE860AF2A20D02E0013C7ED /* Crashlytics.md */,
+				AEE860B02A20D0350013C7ED /* GXFirebaseCrashAnalyticsService.swift */,
+			);
+			path = CrashAnalytics;
 			sourceTree = "<group>";
 		};
 		AEEE718326DEC1780039C5E5 /* SampleExternalObject */ = {

--- a/iOS/GeneXus Frameworks/README.md
+++ b/iOS/GeneXus Frameworks/README.md
@@ -2,4 +2,4 @@
 
 As they are binary, the required .xcframeworks for the sample project are not included in this repository. 
 We are currently in the process of migrating to new forms of distribution (surely using [Swift Packages](https://developer.apple.com/documentation/swift_packages)).
-In order to avoid including binaries in the repository, they are temporarily available for [download from GeneXus Site](https://www.genexus.com/en/developers/downloadcenter?data=5963) (contact your local agent in order to get access).
+In order to avoid including binaries in the repository, they are temporarily available for [download from GeneXus Site](https://www.genexus.com/en/developers/downloadcenter?data=5995) (contact your local agent in order to get access).


### PR DESCRIPTION
Add instruction documentation to support Crash Analytics providers, including sample implementation for Firebase Crashlitycs.