### PR TITLE
Add Android example for obtaining caller's Mini App identifier

### DIFF
--- a/Android/MiniAppCaller/payments/src/main/java/com/genexus/superapps/bankx/payments/PaymentsApi.kt
+++ b/Android/MiniAppCaller/payments/src/main/java/com/genexus/superapps/bankx/payments/PaymentsApi.kt
@@ -11,6 +11,7 @@ import com.genexus.android.core.actions.ActionExecution
 import com.genexus.android.core.base.metadata.expressions.Expression
 import com.genexus.android.core.base.model.Entity
 import com.genexus.android.core.base.model.EntityList
+import com.genexus.android.core.base.services.Services
 import com.genexus.android.core.base.utils.Strings
 import com.genexus.superapps.bankx.payments.services.PaymentsService
 import com.genexus.superapps.bankx.payments.ui.PaymentActivity
@@ -21,13 +22,15 @@ import kotlinx.coroutines.launch
 class PaymentsApi(action: ApiAction?) : ExternalApi(action) {
     private val methodPayWithoutUI = IMethodInvoker { parameters: List<Any> ->
         val amount = parameters[0].toString().toDouble()
-        val paymentId = PaymentsService.pay(amount)
+        val miniAppId = Services.Application.miniApp?.id
+        val paymentId = PaymentsService.pay(amount, miniAppId)
         ExternalApiResult.success(paymentId)
     }
     private val methodPayWithUI: IMethodInvokerWithActivityResult = object : IMethodInvokerWithActivityResult {
         override fun invoke(parameters: List<Any>): ExternalApiResult {
             val amount = parameters[0].toString().toDouble()
-            startActivityForResult(PaymentActivity.newIntent(context, amount), PAYMENT_REQUEST_CODE)
+            val miniAppId = Services.Application.miniApp?.id
+            startActivityForResult(PaymentActivity.newIntent(context, amount, miniAppId), PAYMENT_REQUEST_CODE)
             return ExternalApiResult.SUCCESS_WAIT
         }
 

--- a/Android/MiniAppCaller/payments/src/main/java/com/genexus/superapps/bankx/payments/services/PaymentsService.kt
+++ b/Android/MiniAppCaller/payments/src/main/java/com/genexus/superapps/bankx/payments/services/PaymentsService.kt
@@ -12,8 +12,16 @@ object PaymentsService {
     private const val SDT_PAYMENT_INFORMATION_ITEM_AFFINITY = "affinity"
     private const val SDT_PAYMENT_INFORMATION_ITEM_TYPE = "type"
 
-    fun pay(amount: Double): String {
-        return amount.toString() + "-" + UUID.randomUUID().toString()
+    fun pay(amount: Double, miniAppId: String?): String {
+        val sb = StringBuilder(amount.toString()).apply {
+            append("-")
+            append(UUID.randomUUID().toString())
+            append("-")
+            if (!miniAppId.isNullOrEmpty())
+                append(miniAppId)
+        }
+
+        return sb.toString()
     }
 
     fun getPaymentInformationList(clientInformation: Entity): EntityList {

--- a/Android/MiniAppCaller/payments/src/main/java/com/genexus/superapps/bankx/payments/ui/BottomSheet.kt
+++ b/Android/MiniAppCaller/payments/src/main/java/com/genexus/superapps/bankx/payments/ui/BottomSheet.kt
@@ -21,7 +21,12 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun BottomSheet(@PreviewParameter(AmountProvider::class) amount: Double, succeeded: () -> Unit, canceled: () -> Unit) {
+fun BottomSheet(
+    @PreviewParameter(AmountProvider::class) amount: Double,
+    miniAppId: String,
+    succeeded: () -> Unit,
+    canceled: () -> Unit
+) {
     Surface(
         modifier = Modifier
             .fillMaxWidth()
@@ -33,7 +38,7 @@ fun BottomSheet(@PreviewParameter(AmountProvider::class) amount: Double, succeed
         ) {
             Text(
                 textAlign = TextAlign.Center,
-                text = "Confirm $$amount payment?",
+                text = "Confirm $$amount payment from $miniAppId?",
                 style = MaterialTheme.typography.h6
             )
             Spacer(modifier = Modifier.height(20.dp))

--- a/Android/MiniAppCaller/payments/src/main/java/com/genexus/superapps/bankx/payments/ui/PaymentActivity.kt
+++ b/Android/MiniAppCaller/payments/src/main/java/com/genexus/superapps/bankx/payments/ui/PaymentActivity.kt
@@ -13,10 +13,11 @@ class PaymentActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val amount = intent.extras?.getDouble(EXTRA_AMOUNT) ?: 0.0
+        val miniAppId = intent.extras?.getString(EXTRA_MINIAPP_ID) ?: ""
         setContent {
             BankingSuperAppTheme {
                 PaymentSheet({ canceled() }) {
-                    BottomSheet(amount, { succeeded(amount) }, { canceled() })
+                    BottomSheet(amount, miniAppId, { succeeded(amount, miniAppId) }, { canceled() })
                 }
             }
         }
@@ -27,8 +28,8 @@ class PaymentActivity : ComponentActivity() {
         finish()
     }
 
-    private fun succeeded(amount: Double) {
-        val paymentId = PaymentsService.pay(amount)
+    private fun succeeded(amount: Double, miniAppId: String) {
+        val paymentId = PaymentsService.pay(amount, miniAppId)
         val result = Intent().apply { putExtra(EXTRA_PAYMENT_ID, paymentId) }
         setResult(Activity.RESULT_OK, result)
         finish()
@@ -36,12 +37,15 @@ class PaymentActivity : ComponentActivity() {
 
     companion object {
         private const val EXTRA_AMOUNT = "Amount"
+        private const val EXTRA_MINIAPP_ID = "MiniAppId"
         const val EXTRA_PAYMENT_ID = "PaymentId"
 
-        fun newIntent(context: Context?, amount: Double): Intent {
-            val intent = Intent(context, PaymentActivity::class.java)
-            intent.putExtra(EXTRA_AMOUNT, amount)
-            return intent
+        fun newIntent(context: Context?, amount: Double, miniAppId: String?): Intent {
+            return Intent(context, PaymentActivity::class.java).apply {
+                putExtra(EXTRA_AMOUNT, amount)
+                if (miniAppId != null)
+                    putExtra(EXTRA_MINIAPP_ID, miniAppId)
+            }
         }
     }
 }


### PR DESCRIPTION
This PR adds an Android example for obtaining the caller's mini-app identifier in the external object handler implementation.